### PR TITLE
Fix paths in bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Build artifacts
+build/
+
 # Rojo
 *.rbxl*
 *.rbxm*

--- a/.justfile
+++ b/.justfile
@@ -3,6 +3,7 @@
 set dotenv-load
 
 project_dir := absolute_path("src")
+build_dir := absolute_path("build")
 packages_dir := absolute_path("Packages")
 test_project := "test.project.json"
 
@@ -18,6 +19,13 @@ build:
 
 build-example:
 	rojo build example/default.project.json -o MatterReplicationExample.rbxl
+
+build-package:
+	rm -rf {{ build_dir }}
+	mkdir {{ build_dir }}
+	wally package --output package.tar
+	tar -xvf package.tar -C {{ build_dir }}
+	rm package.tar
 
 lint:
 	selene {{ project_dir }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "luau-lsp.sourcemap.rojoProjectFile": "default.project.json",
+  "luau-lsp.sourcemap.rojoProjectFile": "test.project.json",
   "luau-lsp.ignoreGlobs": [
     "**/_Index/**",
     "**/build/**"

--- a/default.project.json
+++ b/default.project.json
@@ -1,5 +1,5 @@
 {
-  "name": "MatterReplication",
+  "name": "matter-replication",
   "tree": {
     "$path": "src"
   }

--- a/example/default.project.json
+++ b/example/default.project.json
@@ -1,5 +1,5 @@
 {
-  "name": "MatterReplication Example",
+  "name": "matter-replication-example",
   "emitLegacyScripts": false,
   "tree": {
     "$className": "DataModel",

--- a/src/ServerEntity.luau
+++ b/src/ServerEntity.luau
@@ -1,6 +1,4 @@
-local Root = script:FindFirstAncestor("MatterReplication")
-
-local Matter = require(Root.Parent.Matter)
+local Matter = require(script.Parent.Parent.Matter)
 
 export type Data = {
 	id: number,

--- a/src/createReplicationSystem.lua
+++ b/src/createReplicationSystem.lua
@@ -1,14 +1,12 @@
-local Root = script:FindFirstAncestor("MatterReplication")
-
 local Players = game:GetService("Players")
 local RunService = game:GetService("RunService")
 
-local Freeze = require(Root.Parent.Freeze)
-local Matter = require(Root.Parent.Matter)
-local MatterTypes = require(Root.MatterTypes)
-local ServerEntity = require(Root.ServerEntity)
+local Freeze = require(script.Parent.Parent.Freeze)
+local Matter = require(script.Parent.Parent.Matter)
+local MatterTypes = require(script.Parent.MatterTypes)
+local ServerEntity = require(script.Parent.ServerEntity)
 
-local componentReplicated = Root.componentReplicated
+local componentReplicated = script.Parent.componentReplicated
 
 type World = MatterTypes.World
 type Component = MatterTypes.Component<any>

--- a/src/resolveServerId.luau
+++ b/src/resolveServerId.luau
@@ -1,7 +1,5 @@
-local Root = script:FindFirstAncestor("MatterReplication")
-
-local MatterTypes = require(Root.MatterTypes)
-local ServerEntity = require(Root.ServerEntity)
+local MatterTypes = require(script.Parent.MatterTypes)
+local ServerEntity = require(script.Parent.ServerEntity)
 
 type World = MatterTypes.World
 

--- a/test.project.json
+++ b/test.project.json
@@ -1,5 +1,5 @@
 {
-  "name": "MatterReplication",
+  "name": "matter-replication-test",
   "tree": {
     "$className": "DataModel",
     "ReplicatedStorage": {

--- a/wally.toml
+++ b/wally.toml
@@ -3,6 +3,8 @@ name = "vocksel/matter-replication"
 version = "0.1.0"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
+exclude = [ "*" ]
+include = [ "src", "src/**", "default.project.json", "README.md", "LICENSE", ]
 
 [dependencies]
 Matter = "matter-ecs/matter@0.7.1"


### PR DESCRIPTION
I discovered that when consuming the package that the `FindFirstAncestor` paths break the way Wally sets up the instance tree